### PR TITLE
Update definition of 'untriaged' for Toolkit::Telemetry

### DIFF
--- a/bugz.js
+++ b/bugz.js
@@ -60,6 +60,10 @@ class Bug {
   get resolution() {
     return "";
   }
+
+  get severity() {
+    return null;
+  }
 }
 
 class GithubIssue extends Bug {
@@ -98,6 +102,10 @@ class BugzillaBug extends Bug {
 
   get resolution() {
     return this._data.resolution;
+  }
+
+  get severity() {
+    return this._data.severity;
   }
 }
 
@@ -217,6 +225,7 @@ async function loadBugsFromBugzilla(searchParams) {
     "priority",
     "mentors",
     "resolution",
+    "severity",
   ].join(",");
   queryParams.include_fields = include_fields;
 
@@ -246,6 +255,7 @@ async function loadBugsFromBugzilla(searchParams) {
       component: b.component,
       mentors: b.mentors,
       resolution: b.resolution,
+      severity: b.severity,
     };
 
     if (b.assigned_to !== "nobody@mozilla.org") {

--- a/dash.js
+++ b/dash.js
@@ -501,8 +501,12 @@ let bugLists = new Map([
               component: p.component,
             },
             filters: {
-              unprioritized: true,
               open: true,
+              customFilter: (b) => {
+                return b.priority === null ||
+                  (b._data.component === "Telemetry" &&
+                    (b.severity === null || b.severity === "--"));
+              },
             },
           })),
           {


### PR DESCRIPTION
The new triage process is gonna take effect May 4 and includes any bug in a Firefox-related component that has no Severity or current status flag. 

Bugzhub doesn't know what "current" means, but severity is something we can look for.