### PR TITLE
Update the live dashboard link

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -368,6 +368,7 @@ let bugLists = new Map([
         columns: ["assignee", "priority", "title", "whiteboard"],
         searches: [
           {
+            _name: "triaged", // enforcing unique cache key
             search: {
               type: "bugzillaComponent",
               product: "Data Platform and Tools",
@@ -390,6 +391,7 @@ let bugLists = new Map([
         columns: ["assignee", "title", "whiteboard"],
         searches: [
           {
+            _name: "untriaged", // enforcing unique cache key
             search: {
               type: "bugzillaComponent",
               product: "Data Platform and Tools",


### PR DESCRIPTION
The cache key is the JSON-stringified version of `searches`.
For `glean metrics` the cache keys for triaged and untriaged searches
were the same, because filtering is done client-side, not in the search.
Toggling between tabs thus lead to data being read from the cache for
both searches.

Adding a _unique_ (but unused) entry in the search helps to
differentiate between them.