### PR TITLE
Update fork ribbon

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 
   <h1>bugzhub</h1>
 
-  <a href="https://github.com/dexterp37/bugzhub"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"></a>
+  <a href="https://github.com/mozilla/bugzhub"><img style="position: absolute; top: 0; right: 0; border: 0;" loading="lazy" decoding="async" width="149" height="149" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
 
   <div id="categories"></div>
   <div id="content"></div>


### PR DESCRIPTION
Point at mozilla/bugzhub instead of dexter's, and use the canonical fork ribbon from https://github.blog/news-insights/github-ribbons/