### PR TITLE
Remove the unused Glean Python SDK milestone

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -85,7 +85,6 @@ const gleanBugzillaProjects = [
 // Milestones for glean (includes glean-core)
 const gleanMilestones = [
   ["testing", "Improve testing"],
-  ["m13", "Glean Python SDK"],
   ["m17", "High-level docs"],
   ["m18", "Glean JavaScript SDK Feature Parity"],
 ];


### PR DESCRIPTION
It's empty and definitely unused now